### PR TITLE
Updated and verified README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,8 +122,11 @@ and dedication to quality.**
 Image Compression Codec
 ***********************
 
-The graphics format for the game is **dds** format, (though the file extension can 
-be either **png** (preferred as it is lossless), **jpg**, or **bmp**).
+The graphics format for the production assets of the game is the **dds** format, the
+actual file extensions used can be found in `Image Naming (Extension)`_. The source 
+images in this repository are not compressed, and should be saved as **png** (preferred 
+as it is lossless). For historical reasons you will find **jpg** and **bmp** files within 
+the repository, but they are no longer accepted for new submissions.
 
 The minimum texture that is DDS compressed is something like 64x for it to be 
 beneficial as far as speed and size are concerned. Anything smaller than that may 
@@ -159,7 +162,7 @@ need to be scaled down in the game:
 - Interface images
 - Space backgrounds
 
-While this image types require mipmaps:
+While these image types require mipmaps:
 
 - Unit textures
 - Cockpit mesh textures
@@ -171,11 +174,11 @@ In case of doubt please ask one of the developers or on the forum.
 Compression for production
 **************************
 
-Historically the maintainers used *nvcompress* tool for compressing 
+Historically the maintainers used the *nvcompress* tool for compressing 
 textures to dds format. While a few years have passed since the last update 
-of this page, the tools seems to still be around - good for us!
+of this page, the tool seems to still be around - good for us!
 
-This is the link between this reposository and the `production repository 
+This is the link between this repository and the `production repository 
 <https://github.com/vegastrike/Assets-Production>`_ which has the compressed 
 textures used in the game in a mirrored folder structure.
 
@@ -212,7 +215,7 @@ For DXT5 images with smooth transparency gradient:
 
 *Compression with Gimp dds plugin*
 
-Gimp plugin produces dds images with lower quality than that one produced by 
+Gimp plugin produces dds images with lower quality than hose produced by 
 the nvcompress tool. In addition, the plugin uses hardware compression and 
 may produce different results on different systems. Therefore, compressing 
 images with this plugin is not recommended for submission, but can be used as an
@@ -239,7 +242,8 @@ up and with the transition to DDS compressed files we have decided to move
 the extensions to codec-independent naming. The reason for having 2 different
 extensions was to help artists stick to the requirements by making them aware 
 that there is a difference between those 2 extensions. Please note that 
-extensions are coded in some cases so arbitrary interchange might break your graphics.
+extensions are hard-coded in some cases, so arbitrary interchange might break 
+the game's graphics
 
 The following generic, codec independent extensions will be used for graphic files:
 
@@ -247,10 +251,11 @@ The following generic, codec independent extensions will be used for graphic fil
 and gauges, comm animations, splash screens, ...)
 - **.texture** - for textures (unit textures, planet and sun textures, planet rings, 
 sun flares, explosions, blinking lights, warp animations, engine trails, nebulae, ...)
+- **.cube** - for cube maps (space backgrounds)
 
 The difference between .image and .texture is **only** in the *presence* of mipmaps in 
-*.texture* files and *absence* mipmaps in *.image* files. There is no relation 
-whatsoever to directories but depends only on how the graphics is being used.
+*.texture* files and *absence* of mipmaps in *.image* files. There is no relation 
+whatsoever to directories but depends only on how the graphic files are being used.
 The animation directory has subdirectories that have either 2d images or 3d textures. 
 The correct naming has to be evaluated for each new file.
 
@@ -312,8 +317,7 @@ that you have created meets the texture requirements, then:
 - Open a poll for a reasonable period of time (e.g. 1-2 weeks) and describe:
     - which image(s)/texture(s) you'd like to replace; display your candidates
     - briefly describe the method of creation and tools used
-    - If you'd like to replace more than one image/texture, describe how you would 
-assign the favorites of the poll to the individual images/textures
+    - If you'd like to replace more than one image/texture, describe how you would assign the favorites of the poll to the individual images/textures
 
 - After a set period of time
     - announce the winners
@@ -340,8 +344,7 @@ Forum:
 - `In-game graphics artifacts/errors <https://forums.vega-strike.org/viewforum.php?f=27>`_
 
 
-Thank you for your dedication to this project to the original Author of the 
-former wiki page `Pyramid3d <https://github.com/pyramid3d>`_!
+Thank you for your dedication to this project to the original Author of the  wiki page `Pyramid3d <https://github.com/pyramid3d>`_!
 
 
 Folder Structure
@@ -379,7 +382,13 @@ documentation
 
 Written documentation on the game play for user manuals.
 
-NOTE: This needs to get converted to OpenDocument.
+To create the manual from the source ``.tex`` file, use the following command:
+
+``pdflatex VSPlayersGuide.tex``
+
+Install LaTex on Ubuntu with the following command:
+
+``sudo apt-get install texlive-full``
 
 logo
 ****

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,347 @@
 Assets Masters
 ==============
 
-This repository contains the master artwork for the Vega Strike game Upon the Coldest Sea.
+This repository contains the master artwork for the Vega Strike game *Upon the Coldest Sea*.
+
+This page describes generic requirements for art work submissions. The submission should happen 
+without compression, preferably in higher resolution than what will be used in-game to provide 
+for future reuse.
+
+Licenses
+--------
+Please bear in mind that we are bound to accept contributions under the following licenses. 
+This means that if you submit your work for use in Vega Strike, it will be automatically
+licensed under GPL unless you state one of the other licenses:
+
+- (GPL) GNU General Public License
+- (LGPL) GNU Lesser General Public License
+- (GPDL) GNU General Public Documentation License
+- (PD) Public Domain
+- (CC-BY) Creative Commons By Attribution license
+- (CC-SA) Creative Commons Share Alike license
+- (CC-BY-SA) Creative Commons By Attribution Share Alike license
+
+Please note that we do not allow licenses not mentioned above, in particular:
+
+- (CC-NC) Creative Commons Non-Commercial license or any combination with CC-BY and CC-SA
+
+What this means is that, besides the licensing of your work, you need to submit/share the source 
+files, and in terms of artwork, the master/project files for your contributions. If you are not 
+willing to contribute under one of the accepted licenses then please refrain from contributing.
+
+Image types
+-----------
+
+For completeness purposes, the following graphics files are being referred to on this page.
+
+**Textures**
+
+- Unit textures
+- Cockpit mesh textures
+- Planet textures
+
+**Images**
+
+- Base/planet background images
+- HUD images (cockpit, shield, armor, ships, gauges, ...)
+- Main menu images
+- Interface images
+- Cargo images
+- Space backgrounds
+- Animation images
+
+Graphic Files Requirements
+--------------------------
+
+Overview of Graphics Requirements
+*********************************
+
+When submitting textures, please mind the following requirements for successful inclusion in 
+the game:
+
+- Ratio (horizontal:vertical): depending on specific image type (1:1, 2:1, 4:1)
+- Dimensions: following the POT rule (power-of-two), size depending on specific image type
+- Codec: dds with compression type DXT1 (opaque only), DXT1a, DXT3, or DXT5 (with transparency)
+- Extension: .texture for **textures** and .image for **images** (pre-DDS naming png, jpg, 
+bmp still may be found in data)
+- Quality: RQ or CQ
+- Mipmaps: required for **textures**, not required for 2d **images**
+- Tileable (seamless): for some image types
+
+Image ratio
+***********
+
+The **image ratio** horizontal:vertical will depend on the image type. The recommendations 
+are always assuming that pixel ratio is 1:1. This means, no matter what image ratio is used, 
+a circle must show as a circle when viewing the image in an image viewer.
+
+For example, it's 2:1 for planet textures, 1:1 for cargo images, planet hud images and 
+space background faces, 4:1 for current shield and armor face images.
+
+Square things make sense to be 1:1, however other things can be pretty arbitrary, usually 
+you need to round to obtain the closest power of two, for example 400x300 -> 512x256.
+
+Image dimensions
+****************
+
+The vertical and horizontal size of the image should be a **power of two** (POT). Really, 
+non-POT (non-power-of-two) textures are troublesome, time and memory consuming, since
+otherwise they need to be scaled when loaded and it's just best to skip that step. It'd 
+be ideal if they were also power of two in *Asserts-Masters*, but that's not required, 
+but the exports to data4.x (Assets-Production?) should always be some power of 2.
+
+Just use POT. Love the POT. The POT is the mother, the POT is the father. Trust the POT.
+
+That leaves few options for the horizontal or vertical resolution:
+
+- 64 px
+- 128 px
+- 256 px
+- 512 px
+- 1024 px
+- 2048 px
+- 4096 px
+
+1x1 images are allowed, for example if using a texture with a single color, or a 
+transparent image.
+
+The size recommendation will depend on the image type. Please refer to the specific 
+image type requirements in the art-related development section.
+
+Keeping original high resolution image (e.g. 2048 or 4096 px) versions in stock 
+(and in this repository) helps maintaining quality and scalability as game development
+progresses or typical screen resolutions rise in the future with better hardware 
+available to the players. Also, keeping original 3D-models in stock provides for 
+unplanned future changes.
+
+Some images in here are more than 20 years old and in resolutions greater than 2048 px, 
+this means we can still use them today. **Kudos to the original artists for their foresight 
+and dedication to quality.**
+
+Image Compression Codec
+***********************
+
+The graphics format for the game is **dds** format, (though the file extension can 
+be either **png** (preferred as it is lossless), **jpg**, or **bmp**).
+
+The minimum texture that is DDS compressed is something like 64x for it to be 
+beneficial as far as speed and size are concerned. Anything smaller than that may 
+be better off being png, as it won't be compressed anyway.
+
+Allowed compression types are:
+
+- DXT1 for opaque, non alpha layered images only (no transparency).
+- DXT1a for 1 bit alpha layered images. (alpha has only black masking, not shades 
+of grey; simply: parts of the image have full transparency or are completely opaque).
+- DXT3 for semi-transparent images where the transparent layer values are distinct 
+(if the alpha is the same shade across the image, or only varies in chunks).
+- DXT5 for transparent or semi-transparent images (that are translucent and if the 
+translucence varies a lot but not distinctly).
+
+Further clarification: DXT1 is used when the image has no transparent parts at all. 
+DXT1a (DXT1 with alpha channel) is used when the images alpha layer is just 1 value. 
+It's either on or off. If it's off, we should remove the alpha layer from the master 
+and compress with regular DXT1. DXT3 is used if the image has an alpha layer with 
+values other than 0 and 100% but they are not close together. DXT5 takes the same 
+amount of space but it interpolates the alpha layer, for smooth
+transitions between values.
+
+Mipmaps
+*******
+It is recommended to create the following images without mipmaps (sequences of 
+pre-calculated, optimized images that accompany a main texture) as they do not
+need to be scaled down in the game:
+
+- HUD images (cockpit, shield, armor, ships, gauges, ...)
+- Main menu images
+- Cargo images
+- Interface images
+- Space backgrounds
+
+While this image types require mipmaps:
+
+- Unit textures
+- Cockpit mesh textures
+- Animation images
+- Planet textures
+
+In case of doubt please ask one of the developers or on the forum.
+
+Compression for production
+**************************
+
+Historically the maintainers used *nvcompress* tool for compressing 
+textures to dds format. While a few years have passed since the last update 
+of this page, the tools seems to still be around - good for us!
+
+This is the link between this reposository and the `production repository 
+<https://github.com/vegastrike/Assets-Production>`_ which has the compressed 
+textures used in the game in a mirrored folder structure.
+
+Please note that nvcompress (all versions) is invisibly
+corrupting DXT5 compressed textures for older nVidia graphic
+cards principally with drivers before version 169.09. Please
+update to the latest drivers for testing dds textures.
+
+You will need nVidia's free texture tool nvcompress to
+transform your original textures to optimized dds textures. Get
+the tool here: `NVIDIA Texture Tools 
+<http://developer.nvidia.com/object/texture_tools.html>`_
+
+Transform your original texture using nvcompress using one of
+the recommended DXT1, DXT1a, DXT3, or DXT5 formats including or
+excluding mipmaps (option -nomips).
+
+For DXT1 (opaque) images:
+
+``nvcompress -bc1 (-nomips) texture_original.png texture_dds.texture``
+
+For DXT1a images with transparency:
+
+``nvcompress -bc1 -rgb (-nomips) texture_original.png texture_dds.image``
+
+For DXT3 images with transparency:
+
+``nvcompress -bc2 (-nomips) texture_original.png texture_dds.image``
+
+For DXT5 images with smooth transparency gradient:
+
+``nvcompress -bc3 (-nomips) texture_original.png texture_dds.image``
+
+
+*Compression with Gimp dds plugin*
+
+Gimp plugin produces dds images with lower quality than that one produced by 
+the nvcompress tool. In addition, the plugin uses hardware compression and 
+may produce different results on different systems. Therefore, compressing 
+images with this plugin is not recommended for submission, but can be used as an
+alternative method for local testing purposes only.
+
+*Validation and Testing*
+
+Verify the optimized texture either by opening it with GIMP (with gimp-dds 
+plugin installed) and making sure that all mipmap layers (e.g. 12 layers 
+for 2048x2048 original image resolution) are contained in the file, or by 
+checking it with:
+
+``nvddsinfo texture_dds.texture``
+
+It is strongly recommended to actually test the texture or image in game 
+before submitting.
+
+Image Naming (Extension)
+************************
+
+Until version 0.5.0 there were codec extensions being used for graphic files 
+(**png**, **jpg**, or **bmp**). Unfortunately they have become totally mixed 
+up and with the transition to DDS compressed files we have decided to move 
+the extensions to codec-independent naming. The reason for having 2 different
+extensions was to help artists stick to the requirements by making them aware 
+that there is a difference between those 2 extensions. Please note that 
+extensions are coded in some cases so arbitrary interchange might break your graphics.
+
+The following generic, codec independent extensions will be used for graphic files:
+
+- **.image** - for mipmap-less 2d images (backgrounds, ui, cargo, bases, hud images 
+and gauges, comm animations, splash screens, ...)
+- **.texture** - for textures (unit textures, planet and sun textures, planet rings, 
+sun flares, explosions, blinking lights, warp animations, engine trails, nebulae, ...)
+
+The difference between .image and .texture is **only** in the *presence* of mipmaps in 
+*.texture* files and *absence* mipmaps in *.image* files. There is no relation 
+whatsoever to directories but depends only on how the graphics is being used.
+The animation directory has subdirectories that have either 2d images or 3d textures. 
+The correct naming has to be evaluated for each new file.
+
+Artistic Image Quality
+**********************
+
+Committed textures are classified as:
+
+- DQ - Development Quality: textures with very low horizontal resolution and 
+low degree of artistic quality
+- RQ - Release Quality: textures with at least medium horizontal resolution and 
+medium to high degree of artistic quality
+- CQ - Cinematographic Quality: textures with high horizontal resolution and 
+very high degree of artistic quality
+
+Specific resolution requirements can be found on the development pages specific to 
+each image type.
+
+Git Repository Structure
+------------------------
+
+There are two repositories for graphics data which are linked together:
+
+- *Assets-Production* (formerly *data*) which holds the compressed/optimized dds images
+- *Asset-Masters* (formerly *masters*) which holds the original (png) hi-resolution image
+masters plus optionally the source/project files that were used to create the 
+compressed images. No other files will be kept in masters (text, data, sprite files, ...).
+
+Further, the following rules apply to **Asset-Masters (aka this repository)**:
+
+- only original uncompressed images go here
+- they must be placed in the same (relative) directory as in the compressed images 
+in *data*
+- the original images must have the same name as those in *data*
+- Source or project files (.xcf, .blender, ....) are placed in a subdirectory of 
+the original image directory called ``sources``. For example, if the original image is 
+in ``sprites/planets/earth/earth_texture.png``, the source file should be in 
+``sprites/planets/earth/sources/earth_texture.xcf``. This is to keep the source files 
+organized and easily identifiable as related to the original image. The source files 
+must have the same name as the original.
+
+The following naming convention applies for source files:
+
+- instructions file naming: ``imagefile_instructions.txt``
+- copyright/copyleft information should go into: ``imagefile_license.txt``
+- source/project file naming: *Source images should be* ``imagefile_source.xcf`` 
+    *(or whatever extension)*
+
+The Selection and Vetting Process
+---------------------------------
+
+When submitting new art, it is recommended to request feedback from the community 
+through the forum before submitting the images or textures.
+
+The following steps are only required when you are **replacing existing art** which 
+is already of exceptionally high (cinematographic) quality. If the image/texture 
+that you have created meets the texture requirements, then:
+
+- Open a poll for a reasonable period of time (e.g. 1-2 weeks) and describe:
+    - which image(s)/texture(s) you'd like to replace display your candidates
+    - briefly describe the method of creation and tools used
+    - If you'd like to replace more than one image/texture, describe how you would 
+assign the favorites of the poll to the individual images/textures
+
+- After a set period of time
+    - announce the winners
+    - and call the poll closed
+
+For both, submitting **replacement of existing art** or **adding missing art** 
+(provided the new images/textures are not way off-topic):
+
+**Once there is a winer, submit a PR with the textures in this repository 
+(not in Assets-Production)**
+
+
+References
+----------
+
+External:
+
+- `Power of two <http://en.wikipedia.org/wiki/Power_of_two>`_
+- `S3 Texture Compression <http://en.wikipedia.org/wiki/S3_Texture_Compression>`_
+
+Forum:
+
+- `Artwork/data overhauls <https://forums.vega-strike.org/viewforum.php?f=28>`_
+- `In-game graphics artifacts/errors <https://forums.vega-strike.org/viewforum.php?f=27>`_
+
+
+Thank you for your dedication to this project to the original Author of the 
+former wiki page `Pyramid3d <https://github.com/pyramid3d>`_!
+
 
 Areas of Concern
 ----------------

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Assets Masters
 ==============
 
-This repository contains the master artwork for the Vega Strike game *Upon the Coldest Sea*.
+This repository contains the master artwork for the game *Vega Strike: Upon the Coldest Sea*.
 
 This page describes generic requirements for art work submissions. The submission should happen 
 without compression, preferably in higher resolution than what will be used in-game to provide 
@@ -88,8 +88,8 @@ Image dimensions
 The vertical and horizontal size of the image should be a **power of two** (POT). Really, 
 non-POT (non-power-of-two) textures are troublesome, time and memory consuming, since
 otherwise they need to be scaled when loaded and it's just best to skip that step. It'd 
-be ideal if they were also power of two in *Asserts-Masters*, but that's not required, 
-but the exports to data4.x (Assets-Production?) should always be some power of 2.
+be ideal if they were also power of two in *Assets-Masters*, but that's not required, 
+but the exports *Assets-Production* should always be some power of 2.
 
 Just use POT. Love the POT. The POT is the mother, the POT is the father. Trust the POT.
 
@@ -107,7 +107,7 @@ That leaves few options for the horizontal or vertical resolution:
 transparent image.
 
 The size recommendation will depend on the image type. Please refer to the specific 
-image type requirements in the art-related development section.
+image type requirements in the `art-related development section <https://wiki.vega-strike.org/Development>`_.
 
 Keeping original high resolution image (e.g. 2048 or 4096 px) versions in stock 
 (and in this repository) helps maintaining quality and scalability as game development
@@ -140,7 +140,7 @@ of grey; simply: parts of the image have full transparency or are completely opa
 translucence varies a lot but not distinctly).
 
 Further clarification: DXT1 is used when the image has no transparent parts at all. 
-DXT1a (DXT1 with alpha channel) is used when the images alpha layer is just 1 value. 
+DXT1a (DXT1 with alpha channel) is used when the image's alpha layer is just 1 value. 
 It's either on or off. If it's off, we should remove the alpha layer from the master 
 and compress with regular DXT1. DXT3 is used if the image has an alpha layer with 
 values other than 0 and 100% but they are not close together. DXT5 takes the same 
@@ -266,8 +266,8 @@ medium to high degree of artistic quality
 - CQ - Cinematographic Quality: textures with high horizontal resolution and 
 very high degree of artistic quality
 
-Specific resolution requirements can be found on the development pages specific to 
-each image type.
+Specific resolution requirements can be found on the `development pages specific to 
+each image type <https://wiki.vega-strike.org/Development>`_.
 
 Git Repository Structure
 ------------------------
@@ -275,16 +275,16 @@ Git Repository Structure
 There are two repositories for graphics data which are linked together:
 
 - *Assets-Production* (formerly *data*) which holds the compressed/optimized dds images
-- *Asset-Masters* (formerly *masters*) which holds the original (png) hi-resolution image
+- *Assets-Masters* (formerly *masters*) which holds the original (png) hi-resolution image
 masters plus optionally the source/project files that were used to create the 
-compressed images. No other files will be kept in masters (text, data, sprite files, ...).
+compressed images. No other, unrelated files will be kept in *Assets-Masters* (text, data, sprite files, ...).
 
-Further, the following rules apply to **Asset-Masters (aka this repository)**:
+Further, the following rules apply to **Assets-Masters (aka this repository)**:
 
 - only original uncompressed images go here
 - they must be placed in the same (relative) directory as in the compressed images 
-in *data*
-- the original images must have the same name as those in *data*
+in *Assets-Production* 
+- the original images must have the same name as those in *Assets-Production*
 - Source or project files (.xcf, .blender, ....) are placed in a subdirectory of 
 the original image directory called ``sources``. For example, if the original image is 
 in ``sprites/planets/earth/earth_texture.png``, the source file should be in 
@@ -310,7 +310,7 @@ is already of exceptionally high (cinematographic) quality. If the image/texture
 that you have created meets the texture requirements, then:
 
 - Open a poll for a reasonable period of time (e.g. 1-2 weeks) and describe:
-    - which image(s)/texture(s) you'd like to replace display your candidates
+    - which image(s)/texture(s) you'd like to replace; display your candidates
     - briefly describe the method of creation and tools used
     - If you'd like to replace more than one image/texture, describe how you would 
 assign the favorites of the poll to the individual images/textures
@@ -322,7 +322,7 @@ assign the favorites of the poll to the individual images/textures
 For both, submitting **replacement of existing art** or **adding missing art** 
 (provided the new images/textures are not way off-topic):
 
-**Once there is a winer, submit a PR with the textures in this repository 
+**Once there is a winner, submit a PR with the textures in this repository 
 (not in Assets-Production)**
 
 
@@ -344,7 +344,7 @@ Thank you for your dedication to this project to the original Author of the
 former wiki page `Pyramid3d <https://github.com/pyramid3d>`_!
 
 
-Areas of Concern
+Folder Structure
 ----------------
 
 The artwork for the game is divided up into various types. Each section below covers one


### PR DESCRIPTION
Updated the README to have a clean entry into this project. I keep the "Areas of concern" for now, not sure they are that concerning after playing with the repository for a day.

A few notes I made when migrating the wiki page:

- Do we really want people to ask in the forum, is this still monitored? Maybe the issue tracker could be another way to submit contributions?
- The same applies for the "The Selection and Vetting Process", I checked the last conversation and it is a decade old.
- ~I don't think I found the "development" section which is referenced twice, maybe @pyramid3d can chime in if that's just a section on the page or something else~ nvm, I found [the wiki](https://wiki.vega-strike.org/Development:3D_Models) :roll_eyes: Will read through it and add appropriate links, definitely a great source which sheds some lights on the thought process behind things
- Removed: "if several source files are required to execute the project, place them in a zip file" - I don't think it is how things are done in the git age, that would complicate and release script as well

A bit unrelated, but hopefully helpful context. For deployment to production, you need to run `nvcompress` and place the output in the corresponding folder in Assets-Production. I tested this locally with upscaled bases and it works well. As different commands need to be run depending on image transparency, the automation approach needs to be a bit more sophisticated then just walking the directory tree. There are some (currently) unused images as well which don't need to be published to production. But I created a python script which can upscale masters using Real-ESRGAN (4x) and then compresses the output via `nvcompress` and it worked well for sprites.

I also tried the Povray files, apart from some image paths being broken it worked too and allowed me to render the planets for the HUD in any resolution. As some of the used maps have limited resolution it still looks a bit blurry, but with upscaled versions or community contributions in higher resolution this could quickly look pretty impressive even in WQHD (the aspect issue aside).

It looks like the asset generation used to be a multi-step process where i.e. the planets were generated by tweaking the POVRay files and then saving the output into another folder and committing it there.

I wonder if there are sources for the bases which allow recreation of the images in a higher resolution.

Anyways, if this PR makes sense, I'd be happy to continue and look into automation of some tasks, I'd create a separate PR for this.